### PR TITLE
feat(fitimage): integrate MaterialShape support

### DIFF
--- a/kivymd/uix/fitimage/fitimage.py
+++ b/kivymd/uix/fitimage/fitimage.py
@@ -7,7 +7,7 @@ Example
 
 .. tabs::
 
-    .. tab:: Declarative KV styles
+    .. tab:: Imperative Python Styles
 
         .. code-block:: python
 
@@ -41,7 +41,7 @@ Example
             Example().run()
 
 
-    .. tab:: Declarative python styles
+    .. tab:: Declarative Python Styles
 
         .. code-block:: python
 
@@ -85,19 +85,10 @@ from kivy.properties import OptionProperty
 from kivy.uix.image import AsyncImage
 
 from kivymd.uix.behaviors import DeclarativeBehavior, StencilBehavior
+from materialshapes.kivy_widget import MaterialShape
 
 
-class FitImage(DeclarativeBehavior, StencilBehavior, AsyncImage):
-    """
-    Fit image class.
-
-    For more information, see in the
-    :class:`~kivymd.uix.behaviors.declarative_behavior.DeclarativeBehavior` and
-    :class:`~kivy.uix.image.AsyncImage` and
-    :class:`~kivymd.uix.behaviors.stencil_behavior.StencilBehavior`
-    classes documentation.
-    """
-
+class FitImage(DeclarativeBehavior, StencilBehavior, MaterialShape, AsyncImage):
     fit_mode = OptionProperty(
         "cover", options=["scale-down", "fill", "contain", "cover"]
     )
@@ -109,3 +100,295 @@ class FitImage(DeclarativeBehavior, StencilBehavior, AsyncImage):
     :attr:`fit_mode` is a :class:`~kivy.properties.OptionProperty` and
     defaults to `'cover'`.
     """
+
+    shape = OptionProperty(
+        None,
+        options=[
+            "circle",
+            "square",
+            "slanted",
+            "arch",
+            "semiCircle",
+            "oval",
+            "pill",
+            "triangle",
+            "arrow",
+            "fan",
+            "diamond",
+            "clamShell",
+            "pentagon",
+            "gem",
+            "sunny",
+            "verySunny",
+            "cookie4Sided",
+            "cookie6Sided",
+            "cookie7Sided",
+            "cookie9Sided",
+            "cookie12Sided",
+            "clover4Leaf",
+            "clover8Leaf",
+            "burst",
+            "softBurst",
+            "boom",
+            "softBoom",
+            "flower",
+            "puffy",
+            "puffyDiamond",
+            "ghostish",
+            "pixelCircle",
+            "pixelTriangle",
+            "bun",
+            "heart",
+        ],
+    )
+    """
+    The Material shape style applied to the image clipping mask.
+
+    .. versionadded:: 2.0.1
+
+    Available shape options are: `'circle'`, `'square'`, `'slanted'`, `'arch'`,
+    `'semiCircle'`, `'oval'`, `'pill'`, `'triangle'`, `'arrow'`, `'fan'`,
+    `'diamond'`, `'clamShell'`, `'pentagon'`, `'gem'`, `'sunny'`,
+    `'verySunny'`, `'cookie4Sided'`, `'cookie6Sided'`, `'cookie7Sided'`,
+    `'cookie9Sided'`, `'cookie12Sided'`, `'clover4Leaf'`, `'clover8Leaf'`,
+    `'burst'`, `'softBurst'`, `'boom'`, `'softBoom'`, `'flower'`, `'puffy'`,
+    `'puffyDiamond'`, `'ghostish'`, `'pixelCircle'`, `'pixelTriangle'`,
+    `'bun'`, `'heart'`.
+
+    If set to ``None``, the image will be rendered as a standard rectangle.
+
+    :attr:`shape` is an :class:`~kivy.properties.OptionProperty` and
+    defaults to `None`.
+
+    .. tabs::
+    
+        .. tab:: Imperative Python Styles
+    
+            .. code-block:: python
+
+                from kivy.lang import Builder
+                from kivy.metrics import dp
+                
+                from kivymd.app import MDApp
+                from kivymd.uix.boxlayout import MDBoxLayout
+                from kivymd.uix.fitimage import FitImage
+                from kivymd.uix.label import MDLabel
+                
+                KV = '''
+                MDScreen:
+                    md_bg_color: app.theme_cls.surfaceColor
+                
+                    MDScrollView:
+                
+                        MDGridLayout:
+                            id: shape_grid
+                            cols: 6
+                            adaptive_height: True
+                            padding: dp(16)
+                            spacing: dp(16)
+                '''
+
+
+                class ExampleApp(MDApp):
+                    SHAPES = [
+                        "circle",
+                        "square",
+                        "slanted",
+                        "arch",
+                        "semiCircle",
+                        "oval",
+                        "pill",
+                        "triangle",
+                        "arrow",
+                        "fan",
+                        "diamond",
+                        "clamShell",
+                        "pentagon",
+                        "gem",
+                        "sunny",
+                        "verySunny",
+                        "cookie4Sided",
+                        "cookie6Sided",
+                        "cookie7Sided",
+                        "cookie9Sided",
+                        "cookie12Sided",
+                        "clover4Leaf",
+                        "clover8Leaf",
+                        "burst",
+                        "softBurst",
+                        "boom",
+                        "softBoom",
+                        "flower",
+                        "puffy",
+                        "puffyDiamond",
+                        "ghostish",
+                        "pixelCircle",
+                        "pixelTriangle",
+                        "bun",
+                        "heart",
+                    ]
+                    IMAGE_PATH = "bg.jpg"
+
+                    def build(self):
+                        return Builder.load_string(KV)
+
+                    def on_start(self):
+                        grid = self.root.ids.shape_grid
+
+                        for shape_name in self.SHAPES:
+                            item_box = MDBoxLayout(
+                                orientation="vertical",
+                                adaptive_height=True,
+                                spacing=dp(8),
+                            )
+
+                            shape_widget = FitImage(
+                                size_hint=(None, None),
+                                size=(dp(90), dp(90)),
+                                pos_hint={"center_x": 0.5},
+                                shape=shape_name,
+                                source=self.IMAGE_PATH,
+                            )
+
+                            label = MDLabel(
+                                text=shape_name,
+                                halign="center",
+                                adaptive_height=True,
+                                font_style="Label",
+                                role="medium",
+                            )
+
+                            item_box.add_widget(shape_widget)
+                            item_box.add_widget(label)
+                            grid.add_widget(item_box)
+
+
+                if __name__ == "__main__":
+                    ExampleApp().run()
+
+        .. tab:: Declarative Python Styles
+    
+            .. code-block:: python
+
+                from kivy.metrics import dp
+                
+                from kivymd.app import MDApp
+                from kivymd.uix.boxlayout import MDBoxLayout
+                from kivymd.uix.fitimage import FitImage
+                from kivymd.uix.gridlayout import MDGridLayout
+                from kivymd.uix.label import MDLabel
+                from kivymd.uix.scrollview import MDScrollView
+                from kivymd.uix.screen import MDScreen
+
+
+                class ExampleApp(MDApp):
+                    SHAPES = [
+                        "circle",
+                        "square",
+                        "slanted",
+                        "arch",
+                        "semiCircle",
+                        "oval",
+                        "pill",
+                        "triangle",
+                        "arrow",
+                        "fan",
+                        "diamond",
+                        "clamShell",
+                        "pentagon",
+                        "gem",
+                        "sunny",
+                        "verySunny",
+                        "cookie4Sided",
+                        "cookie6Sided",
+                        "cookie7Sided",
+                        "cookie9Sided",
+                        "cookie12Sided",
+                        "clover4Leaf",
+                        "clover8Leaf",
+                        "burst",
+                        "softBurst",
+                        "boom",
+                        "softBoom",
+                        "flower",
+                        "puffy",
+                        "puffyDiamond",
+                        "ghostish",
+                        "pixelCircle",
+                        "pixelTriangle",
+                        "bun",
+                        "heart",
+                    ]
+                    IMAGE_PATH = "bg.jpg"
+
+                    def build(self):
+                        return MDScreen(
+                            MDScrollView(
+                                MDGridLayout(
+                                    *[
+                                        MDBoxLayout(
+                                            FitImage(
+                                                size_hint=(None, None),
+                                                size=(dp(90), dp(90)),
+                                                pos_hint={"center_x": 0.5},
+                                                shape=shape_name,
+                                                source=self.IMAGE_PATH,
+                                            ),
+                                            MDLabel(
+                                                text=shape_name,
+                                                halign="center",
+                                                adaptive_height=True,
+                                                font_style="Label",
+                                                role="medium",
+                                            ),
+                                            orientation="vertical",
+                                            adaptive_height=True,
+                                            spacing=dp(8),
+                                        )
+                                        for shape_name in self.SHAPES
+                                    ],
+                                    cols=6,
+                                    adaptive_height=True,
+                                    padding=dp(16),
+                                    spacing=dp(16),
+                                )
+                            ),
+                            md_bg_color=self.theme_cls.surfaceColor,
+                        )
+
+
+                if __name__ == "__main__":
+                    ExampleApp().run()
+
+    .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/fitimage-shapes.png
+        :align: center
+    """
+
+    def on_source(self, instance, value):
+        """Fired when the :attr:`source` value changes."""
+
+        # Redirecting the path from `source` directly to `MaterialShape.image`.
+        self.image = value
+
+    def update_texture(self, *args):
+        # If the Material shape is specified, we use the MaterialShape logic.
+        if self.shape:
+            super().update_texture(*args)
+            return
+
+    def _get_shape_path(self, ctx):
+        # If the shape is not specified (shape=None), we fill the entire
+        # context with a rectangle.
+        if not self.shape:
+            ctx.rectangle(0, 0, 1, 1)
+            return
+
+        super()._get_shape_path(ctx)
+
+    def _load_source(self, *args):
+        # Block the standard loading of AsyncImage so that it doesn't create
+        # self.texture or draw a rectangle.
+        if self.shape:
+            return
+
+        super()._load_source(*args)


### PR DESCRIPTION
## Description of the problem

`FitImage` previously supported only standard rectangular clipping with rounded corners via the radius property. There was no built-in mechanism to apply `Material Design 3` expressive shape styles (`such as arch, circle, cookie, flower, ghostish,` etc.) to image clipping masks.

## Describe the algorithm of actions that leads to the problem

1. Create a `FitImage` widget.
2. Attempt to apply a Material shape style to clip the image (e.g., setting `shape="arch"` or `shape="cookie4Sided"`).
3. Observe that the shape property is either missing or has no effect on the image rendering.

## Reproducing the problem

```python
from kivymd.app import MDApp
from kivymd.uix.fitimage import FitImage
from kivymd.uix.screen import MDScreen


class Example(MDApp):
    def build(self):
        return MDScreen(
            FitImage(
                source="bg.jpg",
                shape="arch",  # Property 'shape' is not supported
                size_hint=(None, None),
                size=("200dp", "200dp"),
                pos_hint={"center_x": 0.5, "center_y": 0.5},
            )
        )


Example().run()
```

## Screenshots of the problem

None / Feature Request

## Description of Changes

1. Added shape `OptionProperty` to `FitImage` with support for all `Material 3` shape styles (`circle, arch, semiCircle, cookie4Sided, flower,` etc.).
2. Added `MaterialShape` inheritance to `FitImage` to handle vector mask generation using `Cairo`.
3. Updated `on_source` and `_load_source` methods to direct path updates to `MaterialShape.image` and override standard `AsyncImage` texture generation when a shape is set.
4. Added support for `Cairo` pattern generation and image cropping to maintain aspect ratio within `Material` shapes.

## Code for testing new changes

```python
from kivy.metrics import dp

from kivymd.app import MDApp
from kivymd.uix.boxlayout import MDBoxLayout
from kivymd.uix.fitimage import FitImage
from kivymd.uix.gridlayout import MDGridLayout
from kivymd.uix.label import MDLabel
from kivymd.uix.scrollview import MDScrollView
from kivymd.uix.screen import MDScreen


class ExampleApp(MDApp):
    SHAPES = [
        "circle",
        "square",
        "slanted",
        "arch",
        "semiCircle",
        "oval",
        "pill",
        "triangle",
        "arrow",
        "fan",
        "diamond",
        "clamShell",
        "pentagon",
        "gem",
        "sunny",
        "verySunny",
        "cookie4Sided",
        "cookie6Sided",
        "cookie7Sided",
        "cookie9Sided",
        "cookie12Sided",
        "clover4Leaf",
        "clover8Leaf",
        "burst",
        "softBurst",
        "boom",
        "softBoom",
        "flower",
        "puffy",
        "puffyDiamond",
        "ghostish",
        "pixelCircle",
        "pixelTriangle",
        "bun",
        "heart",
    ]
    IMAGE_PATH = "bg.jpg"

    def build(self):
        return MDScreen(
            MDScrollView(
                MDGridLayout(
                    *[
                        MDBoxLayout(
                            FitImage(
                                size_hint=(None, None),
                                size=(dp(90), dp(90)),
                                pos_hint={"center_x": 0.5},
                                shape=shape_name,
                                source=self.IMAGE_PATH,
                            ),
                            MDLabel(
                                text=shape_name,
                                halign="center",
                                adaptive_height=True,
                                font_style="Label",
                                role="medium",
                            ),
                            orientation="vertical",
                            adaptive_height=True,
                            spacing=dp(8),
                        )
                        for shape_name in self.SHAPES
                    ],
                    cols=6,
                    adaptive_height=True,
                    padding=dp(16),
                    spacing=dp(16),
                )
            ),
            md_bg_color=self.theme_cls.surfaceColor,
        )


if __name__ == "__main__":
    ExampleApp().run()
```

## Screenshots of the solution to the problem

<img width="771" height="801" alt="fitimage-shapes" src="https://github.com/user-attachments/assets/5c600551-87e9-4365-a12c-66fbf12dfba0" />
